### PR TITLE
Allow custom BIOS

### DIFF
--- a/vade/src/myem/myem.cpp
+++ b/vade/src/myem/myem.cpp
@@ -33,7 +33,7 @@ void MyEm::Run() {
         }
 }
 
-void MyEm::Load(const std::string& config) {
+int MyEm::Load(const std::string& config) {
         printf("loading config %s..\n", config.c_str());
         auto j = json::parse(config);
         printf("j=%s\n", j.dump().c_str());
@@ -45,8 +45,9 @@ void MyEm::Load(const std::string& config) {
                 m_bios_start = 0x100000 - m_bios_size;
                 m_rom.Bind(m_bios_start, m_bios_start + m_bios_size);
                 m_bus.BindSlave(m_rom);
+                return 0;
         } else {
                 printf("can't open bios (%s)\n", bios.c_str());
-                exit(0);
+                return 1;
         }
 }

--- a/vade/src/myem/myem.h
+++ b/vade/src/myem/myem.h
@@ -23,7 +23,7 @@ class MyEm {
  public:
         MyEm();
         ~MyEm();
-        void Load(const std::string& config);
+        int Load(const std::string& config);
         void Run();
 };
 

--- a/vade/src/myem/myem_test.cpp
+++ b/vade/src/myem/myem_test.cpp
@@ -10,7 +10,9 @@ TEST_F(myem, Myem) {
 	TEST_LOG("Testing MyEm..\n");
 	MyEm m;
 	TEST_LOG("Testing MyEm config..\n");
-	m.Load("{\"bios\":\"vade/pkg/myem/bios.bin\"}");
+	if (m.Load("{\"bios\":\"bios.bin\"}")) {
+		EXPECT_EQ(0, m.Load("{\"bios\":\"vade/pkg/myem/bios.bin\"}"));
+	}
 	TEST_LOG("Testing MyEm run..\n");
 	m.Run();
 }


### PR DESCRIPTION
If `./bios.bin` is present, use it for unit-test.
Otherwise, use the internal pseudo-bios.